### PR TITLE
Making token pools more resilient

### DIFF
--- a/pkg/internal/test_utils.go
+++ b/pkg/internal/test_utils.go
@@ -1,0 +1,25 @@
+package internal
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// allows mocking TimeNowUnix
+// returns a function to cleanup
+func WithTimeMock(t *testing.T, times ...int64) func() {
+	backup := TimeNowUnix
+
+	index := -1
+	TimeNowUnix = func() int64 {
+		index++
+		require.True(t, index < len(times))
+		return times[index]
+	}
+
+	return func() {
+		TimeNowUnix = backup
+		require.Equal(t, len(times)-1, index)
+	}
+}

--- a/pkg/internal/utils.go
+++ b/pkg/internal/utils.go
@@ -1,0 +1,8 @@
+package internal
+
+import "time"
+
+// easier to mock, for tests
+var TimeNowUnix = func() int64 {
+	return time.Now().Unix()
+}

--- a/pkg/request_handler_test.go
+++ b/pkg/request_handler_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/wk8/github-api-proxy/pkg/types"
 
+	"github.com/wk8/github-api-proxy/pkg/internal"
 	mock_token_pools "github.com/wk8/github-api-proxy/pkg/internal/mock_pkg"
 )
 
@@ -42,9 +43,12 @@ func TestRequestHandler_ProxyRequest(t *testing.T) {
 
 		dummyToken := "ohlebeautoken"
 
-		tokenPool.EXPECT().CheckOutToken().Return(&types.TokenSpec{
-			Token:             dummyToken,
-			ExpectedRateLimit: 1000,
+		tokenPool.EXPECT().CheckOutToken().Return(&types.Token{
+			TokenSpec: types.TokenSpec{
+				Token:             dummyToken,
+				ExpectedRateLimit: 1000,
+			},
+			RemainingCalls: 1000,
 		}, nil)
 
 		request, err := githubUpstream.buildRequest(githubUpstream.withResponseHeaders(rateLimitHeader, "1000"))
@@ -64,9 +68,12 @@ func TestRequestHandler_ProxyRequest(t *testing.T) {
 
 		dummyToken := "ohlebeautoken"
 
-		tokenPool.EXPECT().CheckOutToken().Return(&types.TokenSpec{
-			Token:             dummyToken,
-			ExpectedRateLimit: 100,
+		tokenPool.EXPECT().CheckOutToken().Return(&types.Token{
+			TokenSpec: types.TokenSpec{
+				Token:             dummyToken,
+				ExpectedRateLimit: 100,
+			},
+			RemainingCalls: 100,
 		}, nil)
 		tokenPool.EXPECT().UpdateTokenRateLimit(dummyToken, 1000)
 
@@ -87,9 +94,12 @@ func TestRequestHandler_ProxyRequest(t *testing.T) {
 
 		dummyToken := "ohlebeautoken"
 
-		tokenPool.EXPECT().CheckOutToken().Return(&types.TokenSpec{
-			Token:             dummyToken,
-			ExpectedRateLimit: 1000,
+		tokenPool.EXPECT().CheckOutToken().Return(&types.Token{
+			TokenSpec: types.TokenSpec{
+				Token:             dummyToken,
+				ExpectedRateLimit: 1000,
+			},
+			RemainingCalls: 1000,
 		}, nil)
 		remainingCallsStart := 1000
 		remainingCallsStop := 790
@@ -117,9 +127,12 @@ func TestRequestHandler_ProxyRequest(t *testing.T) {
 
 		dummyToken := "ohlebeautoken"
 
-		tokenPool.EXPECT().CheckOutToken().Return(&types.TokenSpec{
-			Token:             dummyToken,
-			ExpectedRateLimit: 111,
+		tokenPool.EXPECT().CheckOutToken().Return(&types.Token{
+			TokenSpec: types.TokenSpec{
+				Token:             dummyToken,
+				ExpectedRateLimit: 111,
+			},
+			RemainingCalls: 111,
 		}, nil)
 		tokenPool.EXPECT().UpdateTokenUsage(dummyToken, 61)
 		tokenPool.EXPECT().UpdateTokenUsage(dummyToken, 11)
@@ -146,14 +159,20 @@ func TestRequestHandler_ProxyRequest(t *testing.T) {
 		dummyToken := "ohlebeautoken"
 		nextToken := "encoreplusbeau"
 
-		tokenPool.EXPECT().CheckOutToken().Return(&types.TokenSpec{
-			Token:             dummyToken,
-			ExpectedRateLimit: 10,
+		tokenPool.EXPECT().CheckOutToken().Return(&types.Token{
+			TokenSpec: types.TokenSpec{
+				Token:             dummyToken,
+				ExpectedRateLimit: 10,
+			},
+			RemainingCalls: 10,
 		}, nil)
 		tokenPool.EXPECT().UpdateTokenUsage(dummyToken, 0)
-		tokenPool.EXPECT().CheckOutToken().Return(&types.TokenSpec{
-			Token:             nextToken,
-			ExpectedRateLimit: 10,
+		tokenPool.EXPECT().CheckOutToken().Return(&types.Token{
+			TokenSpec: types.TokenSpec{
+				Token:             nextToken,
+				ExpectedRateLimit: 10,
+			},
+			RemainingCalls: 10,
 		}, nil)
 
 		handler := NewRequestHandler(githubUpstream.urlStruct(), tokenPool)
@@ -186,14 +205,20 @@ func TestRequestHandler_ProxyRequest(t *testing.T) {
 		dummyToken := "ohlebeautoken"
 		nextToken := "encoreplusbeau"
 
-		tokenPool.EXPECT().CheckOutToken().Return(&types.TokenSpec{
-			Token:             dummyToken,
-			ExpectedRateLimit: 10,
+		tokenPool.EXPECT().CheckOutToken().Return(&types.Token{
+			TokenSpec: types.TokenSpec{
+				Token:             dummyToken,
+				ExpectedRateLimit: 10,
+			},
+			RemainingCalls: 10,
 		}, nil)
 		tokenPool.EXPECT().UpdateTokenUsage(dummyToken, 0)
-		tokenPool.EXPECT().CheckOutToken().Return(&types.TokenSpec{
-			Token:             nextToken,
-			ExpectedRateLimit: 10,
+		tokenPool.EXPECT().CheckOutToken().Return(&types.Token{
+			TokenSpec: types.TokenSpec{
+				Token:             nextToken,
+				ExpectedRateLimit: 10,
+			},
+			RemainingCalls: 10,
 		}, nil)
 
 		handler := NewRequestHandler(githubUpstream.urlStruct(), tokenPool)
@@ -226,13 +251,19 @@ func TestRequestHandler_ProxyRequest(t *testing.T) {
 		dummyToken := "ohlebeautoken"
 		nextToken := "encoreplusbeau"
 
-		tokenPool.EXPECT().CheckOutToken().Return(&types.TokenSpec{
-			Token:             dummyToken,
-			ExpectedRateLimit: 1000,
+		tokenPool.EXPECT().CheckOutToken().Return(&types.Token{
+			TokenSpec: types.TokenSpec{
+				Token:             dummyToken,
+				ExpectedRateLimit: 1000,
+			},
+			RemainingCalls: 1000,
 		}, nil)
-		tokenPool.EXPECT().CheckOutToken().Return(&types.TokenSpec{
-			Token:             nextToken,
-			ExpectedRateLimit: 1000,
+		tokenPool.EXPECT().CheckOutToken().Return(&types.Token{
+			TokenSpec: types.TokenSpec{
+				Token:             nextToken,
+				ExpectedRateLimit: 1000,
+			},
+			RemainingCalls: 1000,
 		}, nil)
 
 		githubUpstream.resetRequestsCount()
@@ -257,9 +288,12 @@ func TestRequestHandler_ProxyRequest(t *testing.T) {
 
 		dummyToken := "ohlebeautoken"
 
-		tokenPool.EXPECT().CheckOutToken().Return(&types.TokenSpec{
-			Token:             dummyToken,
-			ExpectedRateLimit: 1000,
+		tokenPool.EXPECT().CheckOutToken().Return(&types.Token{
+			TokenSpec: types.TokenSpec{
+				Token:             dummyToken,
+				ExpectedRateLimit: 1000,
+			},
+			RemainingCalls: 1000,
 		}, nil)
 
 		githubUpstream.resetRequestsCount()
@@ -375,16 +409,22 @@ func TestRequestHandler_ProxyRequest(t *testing.T) {
 		nextToken := "encoreplusbeau"
 		bothTokens := []string{dummyToken, nextToken}
 
-		tokenPool.EXPECT().CheckOutToken().Return(&types.TokenSpec{
-			Token:             dummyToken,
-			ExpectedRateLimit: 250,
+		tokenPool.EXPECT().CheckOutToken().Return(&types.Token{
+			TokenSpec: types.TokenSpec{
+				Token:             dummyToken,
+				ExpectedRateLimit: 250,
+			},
+			RemainingCalls: 250,
 		}, nil)
 		for remaining := 200; remaining >= 0; remaining -= remainingCallsReportingInterval {
 			tokenPool.EXPECT().UpdateTokenUsage(dummyToken, remaining)
 		}
-		tokenPool.EXPECT().CheckOutToken().Return(&types.TokenSpec{
-			Token:             nextToken,
-			ExpectedRateLimit: 250,
+		tokenPool.EXPECT().CheckOutToken().Return(&types.Token{
+			TokenSpec: types.TokenSpec{
+				Token:             nextToken,
+				ExpectedRateLimit: 250,
+			},
+			RemainingCalls: 250,
 		}, nil)
 		for remaining := 200; remaining >= remainingCallsReportingInterval; remaining -= remainingCallsReportingInterval {
 			tokenPool.EXPECT().UpdateTokenUsage(nextToken, remaining)
@@ -438,19 +478,25 @@ func TestRequestHandler_ProxyRequest(t *testing.T) {
 		dummyToken := "ohlebeautoken"
 		nextToken := "encoreplusbeau"
 
-		tokenPool.EXPECT().CheckOutToken().Return(&types.TokenSpec{
-			Token:             dummyToken,
-			ExpectedRateLimit: 1000,
+		tokenPool.EXPECT().CheckOutToken().Return(&types.Token{
+			TokenSpec: types.TokenSpec{
+				Token:             dummyToken,
+				ExpectedRateLimit: 1000,
+			},
+			RemainingCalls: 1000,
 		}, nil)
-		tokenPool.EXPECT().CheckOutToken().Return(&types.TokenSpec{
-			Token:             nextToken,
-			ExpectedRateLimit: 10,
+		tokenPool.EXPECT().CheckOutToken().Return(&types.Token{
+			TokenSpec: types.TokenSpec{
+				Token:             nextToken,
+				ExpectedRateLimit: 10,
+			},
+			RemainingCalls: 10,
 		}, nil)
 
 		handler := NewRequestHandler(githubUpstream.urlStruct(), tokenPool)
 
 		// a fist request, that says it resets in 30 secs
-		resetIn30Secs := timeNowUnix() + 30
+		resetIn30Secs := internal.TimeNowUnix() + 30
 		request, err := githubUpstream.buildRequest(githubUpstream.withResponseHeaders(resetTimestampHeader, strconv.FormatInt(resetIn30Secs, 10)))
 		require.NoError(t, err)
 		response, body, ok := assertHandleRequestSuccessful(t, handler, request, http.StatusOK)
@@ -476,18 +522,24 @@ func TestRequestHandler_ProxyRequest(t *testing.T) {
 		dummyToken := "ohlebeautoken"
 		nextToken := "encoreplusbeau"
 
-		tokenPool.EXPECT().CheckOutToken().Return(&types.TokenSpec{
-			Token:             dummyToken,
-			ExpectedRateLimit: 1000,
+		tokenPool.EXPECT().CheckOutToken().Return(&types.Token{
+			TokenSpec: types.TokenSpec{
+				Token:             dummyToken,
+				ExpectedRateLimit: 1000,
+			},
+			RemainingCalls: 1000,
 		}, nil)
-		tokenPool.EXPECT().CheckOutToken().Return(&types.TokenSpec{
-			Token:             nextToken,
-			ExpectedRateLimit: 10,
+		tokenPool.EXPECT().CheckOutToken().Return(&types.Token{
+			TokenSpec: types.TokenSpec{
+				Token:             nextToken,
+				ExpectedRateLimit: 10,
+			},
+			RemainingCalls: 10,
 		}, nil)
 
 		handler := NewRequestHandler(githubUpstream.urlStruct(), tokenPool)
 
-		defer withTimeMock(t, 1000, 4540, 4540)()
+		defer internal.WithTimeMock(t, 1000, 4540, 4540)()
 
 		// first request
 		request, err := githubUpstream.buildRequest()
@@ -530,9 +582,12 @@ func TestRequestHandler_HandleGithubAPIRequest(t *testing.T) {
 
 		dummyToken := "ohlebeautoken"
 
-		tokenPool.EXPECT().CheckOutToken().Return(&types.TokenSpec{
-			Token:             dummyToken,
-			ExpectedRateLimit: 1000,
+		tokenPool.EXPECT().CheckOutToken().Return(&types.Token{
+			TokenSpec: types.TokenSpec{
+				Token:             dummyToken,
+				ExpectedRateLimit: 1000,
+			},
+			RemainingCalls: 1000,
 		}, nil)
 
 		reqBody := "hey you"
@@ -569,9 +624,12 @@ func TestRequestHandler_HandleGithubAPIRequest(t *testing.T) {
 
 		dummyToken := "ohlebeautoken"
 
-		tokenPool.EXPECT().CheckOutToken().Return(&types.TokenSpec{
-			Token:             dummyToken,
-			ExpectedRateLimit: 1000,
+		tokenPool.EXPECT().CheckOutToken().Return(&types.Token{
+			TokenSpec: types.TokenSpec{
+				Token:             dummyToken,
+				ExpectedRateLimit: 1000,
+			},
+			RemainingCalls: 1000,
 		}, nil)
 
 		request, err := proxy.buildRequest()
@@ -856,20 +914,4 @@ type failingTransport struct{}
 
 func (f failingTransport) RoundTrip(request *http.Request) (*http.Response, error) {
 	return nil, failingTransportError
-}
-
-// returns a function to cleanup
-func withTimeMock(t *testing.T, times ...int64) func() {
-	backup := timeNowUnix
-
-	index := -1
-	timeNowUnix = func() int64 {
-		index++
-		require.True(t, index < len(times))
-		return times[index]
-	}
-
-	return func() {
-		timeNowUnix = backup
-	}
 }

--- a/pkg/token-pools/in_memory_test.go
+++ b/pkg/token-pools/in_memory_test.go
@@ -1,0 +1,38 @@
+package token_pools
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestInMemoryTokenPool(t *testing.T) {
+	t.Run("Checkout with randomization", func(t *testing.T) {
+		nCalls := 100
+		counts := make(map[string]int)
+
+		nTokens := 10
+		allChars := make([]rune, 0, nTokens)
+		for char := 'a'; char < 'a'+int32(nTokens); char++ {
+			allChars = append(allChars, char)
+		}
+
+		for i := 0; i < nCalls; i++ {
+			pool := newInMemoryTokenPool(true)
+
+			require.NoError(t, pool.EnsureTokensAre(generateTokenSpecs(allChars...)...))
+
+			token, err := pool.CheckOutToken()
+			require.NoError(t, err)
+			counts[token.Token]++
+		}
+
+		totalCount := 0
+		for char := 'a'; char < 'a'+int32(nTokens); char++ {
+			totalCount += counts[tokenFromChar(char)]
+		}
+
+		require.Equal(t, nCalls, totalCount)
+		require.Less(t, 1, len(counts))
+	})
+}

--- a/pkg/token-pools/test_utils.go
+++ b/pkg/token-pools/test_utils.go
@@ -1,0 +1,28 @@
+package token_pools
+
+import (
+	"strings"
+
+	"github.com/wk8/github-api-proxy/pkg/types"
+)
+
+const defaultRateLimit = 5000
+
+func generateTokenSpecs(chars ...rune) []*types.TokenSpec {
+	specs := make([]*types.TokenSpec, len(chars))
+	for i, c := range chars {
+		specs[i] = generateTokenSpec(c)
+	}
+	return specs
+}
+
+func generateTokenSpec(char rune) *types.TokenSpec {
+	return &types.TokenSpec{
+		Token:             tokenFromChar(char),
+		ExpectedRateLimit: defaultRateLimit,
+	}
+}
+
+func tokenFromChar(c rune) string {
+	return strings.Repeat(string(c), 40)
+}

--- a/pkg/token-pools/token_pool.go
+++ b/pkg/token-pools/token_pool.go
@@ -24,10 +24,13 @@ type TokenPoolStorageBackend interface {
 	EnsureTokensAre(tokens ...*types.TokenSpec) error
 
 	// CheckOutToken checks out a token with its full hourly quota available, if there are any.
-	// The storage should keep track of when the token was checked out, and mark it as checked out.
+	// If there are no token available that hasn't been checked out yet, it should check out the token
+	// that has the most calls remaining, if any.
+	// The storage should keep track of when the token was checked out, and mark it as checked out
+	// (if it was already checked out, the checked-out timestamp should be kept to its original value).
 	// Errors are only for real storage errors; if the storage is working as intended, but simply
 	// has no remaining token, it should just reply (nil, nil).
-	CheckOutToken() (*types.TokenSpec, error)
+	CheckOutToken() (*types.Token, error)
 
 	// UpdateTokenUsage should update a given checked-out token's count of remaining calls.
 	// Trying to update a token that's unknown to the storage shouldn't yield an error, as this
@@ -35,7 +38,7 @@ type TokenPoolStorageBackend interface {
 	UpdateTokenUsage(token string, remaining int) error
 
 	// UpdateTokenRateLimit should update a given token's rate limit, in case the config gave
-	// a wrong value for it
+	// a wrong value for it.
 	// Same as UpdateTokenUsage, trying to update a token that's unknown to the storage shouldn't yield an error.
 	UpdateTokenRateLimit(token string, rateLimit int) error
 

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -6,6 +6,11 @@ type TokenSpec struct {
 	ExpectedRateLimit int `yaml:"expected_rate_limit"`
 }
 
+type Token struct {
+	TokenSpec
+	RemainingCalls int
+}
+
 type TLSConfig struct {
 	CrtPath string `yaml:"crt_path"`
 	KeyPath string `yaml:"key_path"`


### PR DESCRIPTION
By allowing them to checkout the same token multiple times if there are no
unused tokens to pick from.

Added more tests, and more logging.